### PR TITLE
Replaced deprecated MapQuest tile layer by OSM

### DIFF
--- a/examples/example.html
+++ b/examples/example.html
@@ -21,7 +21,7 @@
 					center: [58.0, -11.0],
 					zoom: 4,
 					layers: [
-						new L.tileLayer('http://{s}.tile.openstreetmap.se/hydda/full/{z}/{x}/{y}.png', {
+						L.tileLayer('http://{s}.tile.openstreetmap.se/hydda/full/{z}/{x}/{y}.png', {
 							minZoom: 0,
 							maxZoom: 18,
 							attribution: 'Tiles courtesy of <a href="http://openstreetmap.se/" target="_blank">OpenStreetMap Sweden</a> &mdash; Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'

--- a/examples/example.html
+++ b/examples/example.html
@@ -21,11 +21,11 @@
 					center: [58.0, -11.0],
 					zoom: 4,
 					layers: [
-					  new L.TileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
-						attribution: 'Tiles Courtesy of <a href="http://www.mapquest.com/">MapQuest</a> &mdash; Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-						maxZoom: 18,
-						subdomains: '1234'
-					  })
+						new L.tileLayer('http://{s}.tile.openstreetmap.se/hydda/full/{z}/{x}/{y}.png', {
+							minZoom: 0,
+							maxZoom: 18,
+							attribution: 'Tiles courtesy of <a href="http://openstreetmap.se/" target="_blank">OpenStreetMap Sweden</a> &mdash; Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
+						})
 					]
 				});
 


### PR DESCRIPTION
Hi,

Thank you for the nice Leaflet plugin!

The basic demo is "broken" due to MapQuest having discontinued the direct access to their tiles (including to Open MapQuest), as of 11-July-2016.
http://devblog.mapquest.com/2016/06/15/modernization-of-mapquest-results-in-changes-to-open-tile-access/

Simply replaced the tiles provider by OSM Sweden, as the 2 other demos.

Note: you might be interested in reflecting the change on the `master` branch as well.