### PR TITLE
Fixed rendering issues with detailed polylines

### DIFF
--- a/leaflet.polylineoffset.js
+++ b/leaflet.polylineoffset.js
@@ -103,7 +103,7 @@ var PolylineOffset = {
     },
 
     offsetPoints: function(pts, offset) {
-        var offsetSegments = this.offsetPointLine(pts, offset);
+        var offsetSegments = this.offsetPointLine(L.LineUtil.simplify(pts, 1.0), offset);
         return this.joinLineSegments(offsetSegments, offset);
     },
 

--- a/leaflet.polylineoffset.js
+++ b/leaflet.polylineoffset.js
@@ -102,9 +102,9 @@ var PolylineOffset = {
         return offsetSegments;
     },
 
-    offsetPoints: function(pts, offset) {
-        var offsetSegments = this.offsetPointLine(L.LineUtil.simplify(pts, 1.0), offset);
-        return this.joinLineSegments(offsetSegments, offset);
+    offsetPoints: function(pts, options) {
+        var offsetSegments = this.offsetPointLine(L.LineUtil.simplify(pts, options.smoothFactor), options.offset);
+        return this.joinLineSegments(offsetSegments, options.offset);
     },
 
     /**
@@ -199,7 +199,7 @@ L.Polyline.include({
 
             // Offset management hack ---
             if (this.options.offset) {
-                ring = L.PolylineOffset.offsetPoints(ring, this.options.offset);
+                ring = L.PolylineOffset.offsetPoints(ring, this.options);
             }
             // Offset management hack END ---
 


### PR DESCRIPTION
Added the simplify step before offsetting the actual point. This reduces the number of points in the line and smooths it. The end result is unaffected in simple polylines and is significantly improved on detailed polylines.

This should fix issues as seen in #1 